### PR TITLE
Add Element.prototype.matches polyfill to support IE11.

### DIFF
--- a/src/hierarchySlicer.ts
+++ b/src/hierarchySlicer.ts
@@ -37,6 +37,7 @@ import { select, Selection } from "d3-selection";
 import { isEqual } from "lodash-es";
 
 import "@babel/polyfill";
+import "./matchesPolyfill";
 
 import "../style/hierarchySlicer.less";
 

--- a/src/matchesPolyfill.js
+++ b/src/matchesPolyfill.js
@@ -1,0 +1,14 @@
+if (!Element.prototype.matches) {
+    Element.prototype.matches = 
+        Element.prototype.matchesSelector || 
+        Element.prototype.mozMatchesSelector ||
+        Element.prototype.msMatchesSelector || 
+        Element.prototype.oMatchesSelector || 
+        Element.prototype.webkitMatchesSelector ||
+        function(s) {
+          var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+              i = matches.length;
+          while (--i >= 0 && matches.item(i) !== this) {}
+          return i > -1;            
+        };
+  }


### PR DESCRIPTION
d3-selection uses Element.matches inside of filter function.
And filter method of D3 calls in renderSelection:
https://github.com/liprec/powerbi-hierarchySlicer/blob/v2/src/hierarchySlicerWebBehavior.ts#L334

It gives fails on clear selection in IE11